### PR TITLE
Ports Deafness Cap

### DIFF
--- a/modular_warrenstation/deafness_cap/code/deafness_limit.dm
+++ b/modular_warrenstation/deafness_cap/code/deafness_limit.dm
@@ -1,0 +1,23 @@
+/datum/component/limit_deafness
+	// How many ticks of deafness is our maximum?
+	var/max_deafness_ticks = 10
+
+/datum/component/limit_deafness/Initialize(...)
+	. = ..()
+	if (!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	RegisterSignal(parent, COMSIG_LIVING_LIFE, PROC_REF(deaf_check))
+
+/datum/component/limit_deafness/proc/deaf_check(mob/living/whatdidyousay)
+	var/mob/living/carbon/human/speakup = whatdidyousay
+	var/obj/item/organ/internal/ears/target_ears = speakup?.get_organ_slot(ORGAN_SLOT_EARS)
+
+	if (target_ears)
+		if (target_ears.deaf > max_deafness_ticks)
+			target_ears.deaf = min(max_deafness_ticks, target_ears.deaf)
+			to_chat(speakup, span_notice("The ringing in your ears begins to fade..."))
+
+/mob/living/carbon/human/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/limit_deafness)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8329,5 +8329,5 @@
 #include "modular_warrenstation/money_rework/code/atm.dm"
 #include "modular_warrenstation/money_rework/code/money.dm"
 #include "modular_warrenstation/money_rework/code/moneyspawners.dm"
-#include "modular_warrenstation\deafness_cap\code\deafness_limit.dm"
+#include "modular_warrenstation/deafness_cap/code/deafness_limit.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8329,4 +8329,5 @@
 #include "modular_warrenstation/money_rework/code/atm.dm"
 #include "modular_warrenstation/money_rework/code/money.dm"
 #include "modular_warrenstation/money_rework/code/moneyspawners.dm"
+#include "modular_warrenstation\deafness_cap\code\deafness_limit.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

Requested port, caps deafness to 10 tick limit from NovaSector

-PR Could not be fully tested due to mapgen issues affecting game launch.
-Code builds correctly with no issues

## Why It's Good For The Game

Requested port.

## Changelog

:cl: Koltsov
balance: Deafness capped at 10 ticks
/:cl:
