### PR TITLE
Ports Bitrunner Prefloading

### DIFF
--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -315,7 +315,16 @@
 		if(isnull(wayout))
 			balloon_alert(neo, "out of bandwidth!")
 			return
-		current_avatar = server.generate_avatar(wayout, netsuit)
+		// BEGIN EDIT - ADD PREFS
+		var/datum/preferences/pref
+		var/load_loadout = FALSE
+		var/obj/item/bitrunning_disk/prefs/prefdisk = locate() in neo.get_contents()
+		if(prefdisk)
+			load_loadout = prefdisk.include_loadout
+			pref = prefdisk.loaded_preference
+		current_avatar = server.generate_avatar(wayout, netsuit, pref, include_loadout = load_loadout)  // Added the prefs argument
+		// END EDIT - ADD PREFS
+
 		avatar_ref = WEAKREF(current_avatar)
 		server.stock_gear(current_avatar, neo, generated_domain)
 

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -36,7 +36,7 @@
 	return chosen_turf
 
 /// Generates a new avatar for the bitrunner.
-/obj/machinery/quantum_server/proc/generate_avatar(obj/structure/hololadder/wayout, datum/outfit/netsuit,, datum/preferences/prefs, include_loadout = FALSE) // EDIT - PREFS
+/obj/machinery/quantum_server/proc/generate_avatar(obj/structure/hololadder/wayout, datum/outfit/netsuit, datum/preferences/prefs, include_loadout = FALSE) // EDIT - PREFS
 	var/mob/living/carbon/human/avatar = new(wayout.loc)
 
 		// BEGIN EDIT - PREFS!

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -36,9 +36,14 @@
 	return chosen_turf
 
 /// Generates a new avatar for the bitrunner.
-/obj/machinery/quantum_server/proc/generate_avatar(obj/structure/hololadder/wayout, datum/outfit/netsuit)
+/obj/machinery/quantum_server/proc/generate_avatar(obj/structure/hololadder/wayout, datum/outfit/netsuit,, datum/preferences/prefs, include_loadout = FALSE) // EDIT - PREFS
 	var/mob/living/carbon/human/avatar = new(wayout.loc)
 
+		// BEGIN EDIT - PREFS!
+	if(!isnull(prefs))
+		prefs.safe_transfer_prefs_to(avatar)
+	ADD_TRAIT(avatar, TRAIT_CANNOT_CRYSTALIZE, "Bitrunning") // Stops the funny ethereal bug
+		// END EDIT - PREFS
 	var/outfit_path = generated_domain.forced_outfit || netsuit
 	var/datum/outfit/to_wear = new outfit_path()
 
@@ -74,6 +79,8 @@
 			new /obj/item/flashlight,
 		)
 
+	if(include_loadout)
+		avatar.equip_outfit_and_loadout(new /datum/outfit(), prefs) // EDIT - LOADOUTS
 	var/obj/item/card/id/outfit_id = avatar.wear_id
 	if(outfit_id)
 		outfit_id.assignment = "Bit Avatar"

--- a/modular_warrenstation/code/modules/bitrunning/disks.dm
+++ b/modular_warrenstation/code/modules/bitrunning/disks.dm
@@ -1,0 +1,52 @@
+/obj/item/bitrunning_disk/prefs
+	name = "DeForest biological simulation disk"
+	desc = "A disk containing the biological simulation data necessary to load custom characters into bitrunning domains."
+	icon = 'icons/obj/devices/circuitry_n_data.dmi'
+	base_icon_state = "datadisk"
+	icon_state = "datadisk0"
+
+	w_class = WEIGHT_CLASS_SMALL
+
+	var/datum/preferences/loaded_preference
+
+	var/include_loadout = FALSE
+
+/obj/item/bitrunning_disk/prefs/examine(mob/user)
+	. = ..()
+	if(!isnull(loaded_preference))
+		var/name = loaded_preference.read_preference(/datum/preference/name/real_name)
+		. += "It currently has the character [name] loaded, with loadouts [(include_loadout ? "enabled" : "disabled")]"
+		. += span_notice("Ctrl-Click to change loadout loading")
+
+/obj/item/bitrunning_disk/prefs/CtrlClick(mob/user)
+	. = ..()
+	include_loadout = !include_loadout // We just switch this around. Elegant!
+	balloon_alert(user, include_loadout ? "Loadout enabled" : "Loadout disabled")
+
+/obj/item/bitrunning_disk/prefs/attack_self(mob/user, modifiers)
+	. = ..()
+
+	var/list/prefdata_names = user.client.prefs?.create_character_profiles()
+	if(isnull(prefdata_names))
+		return
+
+	var/response = tgui_alert(user, message = "Change selected prefs?", title = "Prefchange", buttons = list("Yes", "No"))
+	if(isnull(response) || response == "No")
+		return
+	var/choice = tgui_input_list(user, message = "Select a character",  title = "Character selection", items = prefdata_names)
+	if(isnull(choice) || !user.is_holding(src))
+		return
+
+	loaded_preference = new(user.client)
+	loaded_preference.load_character(prefdata_names.Find(choice))
+
+	balloon_alert(user, "Character set")
+	to_chat(user, span_notice("Character set to [choice] sucessfully!"))
+
+/datum/outfit/job/bitrunner
+	r_pocket = /obj/item/bitrunning_disk/prefs
+
+/datum/orderable_item/bitrunning_tech/pref_item
+	cost_per_order = 500
+	item_path = /obj/item/bitrunning_disk/prefs
+	desc = "This disk contains a program that lets you load in custom characters."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8332,6 +8332,7 @@
 #include "modular_warrenstation/deafness_cap/code/deafness_limit.dm"
 #include "modular_warrenstation/code/modules/ammo_stacks/code/ammo_stack_base.dm"
 #include "modular_warrenstation/code/modules/ammo_stacks/code/stack_types.dm"
+#include "modular_warrenstation\code\modules\bitrunning\disks.dm"
 #include "modular_warrenstation\mobs\lethalmobs.dm"
 #include "modular_warrenstation\mobs\mob_ai.dm"
 #include "modular_warrenstation\mobs\mob_dsword.dm"


### PR DESCRIPTION
## About The Pull Request

Requested port, adds prefloading to the bitrunner role from Bubberstation

-PR Could not be fully tested due to mapgen issues affecting game launch.
-Code builds correctly with no issues

## Why It's Good For The Game

Requested port.

## Changelog

:cl: Koltsov
code: Ability to load prefs as bitrunner
/:cl:
